### PR TITLE
stripped HTML away from HV suggested agg var

### DIFF
--- a/frontend/components/Builder/Project/Visualize/Document/Sections/HypothesisVisualizer/Controller/Axes/AxesCorrAnalysis.js
+++ b/frontend/components/Builder/Project/Visualize/Document/Sections/HypothesisVisualizer/Controller/Axes/AxesCorrAnalysis.js
@@ -86,11 +86,13 @@ print("Py code parameters", parameters)
     return JSON.parse(task.settings?.aggregateVariables || "[]");
   }) || [];
   const formattedItems = optionsAggVar.map(item => {
-    console.log(item);
+    const parser = new DOMParser();
+    const parsedDoc = parser.parseFromString(item, "text/html");
+    const strippedContent = parsedDoc.body.textContent || "";
     return {
-      key: item.toLowerCase().replace(/\s+/g, '-'),
-      text: item,
-      value: item
+      key: strippedContent.toLowerCase().replace(/\s+/g, '-'),
+      text: strippedContent,
+      value: strippedContent
     };
   });
 


### PR DESCRIPTION
Just a quick fix to sanitize the suggested Aggregate variable under the dropdown option of the HV fill-the-hole-sentences