### PR TITLE
Collab for local production and YQ's backend

### DIFF
--- a/frontend/components/TipTap/Main.js
+++ b/frontend/components/TipTap/Main.js
@@ -16,7 +16,7 @@ import { Button, Dropdown } from "semantic-ui-react";
 import { useApolloClient } from "@apollo/client";
 
 import CollaborationCursorExtension from "./CollaborationCursorExtension";
-import { endpoint, prodEndpoint } from "../../config";
+import { collabEndpoint, endpoint, prodEndpoint } from "../../config";
 
 import DesignSystemButton from "../DesignSystem/Button";
 import { StyledTipTap } from "./StyledTipTap";
@@ -89,8 +89,12 @@ function getCollaborationUrl() {
   // endpoint. The client bundle's NODE_ENV can be undefined in production, so an
   // inverted `=== "production"` check would wrongly fall back to localhost.
   const gql =
-    process.env.NODE_ENV === "development" ? endpoint : prodEndpoint;
-  const base = (gql || "http://localhost:4444/api/graphql").replace(
+    process.env.NODE_ENV === "development" ? collabEndpoint : prodEndpoint;
+
+  // We should replace this with a more proper "collabEndpoint" and "prodCollabEndpoint"
+  // Where the local collab endpoint is ws://localhost:4445/collaboration
+  // And the production is the same as the backend endpoint but with wss and the /collaboration extension
+  const base = (gql || "http://localhost:4445/api/graphql").replace(
     /\/api\/graphql\/?$/,
     "",
   );

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -52,7 +52,7 @@ const securityHeaders = [
       // files.pythonhosted.org: Pyodide micropip downloads wheel files from here
       // ws://localhost:4444: dev collaborative-editing WebSocket (Hocuspocus);
       // production uses wss://*.mindhive.science (already covered above).
-      "connect-src 'self' http://localhost:4444 ws://localhost:4444 https://*.mindhive.science https://accounts.google.com https://apis.google.com wss://*.mindhive.science https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org https://api.cloudinary.com",
+      "connect-src 'self' http://localhost:4444 ws://localhost:4445 ws://localhost:4444 https://*.mindhive.science https://accounts.google.com https://apis.google.com wss://*.mindhive.science https://cdn.jsdelivr.net https://pypi.org https://files.pythonhosted.org https://api.cloudinary.com",
       // iframes for Google OAuth popup + supported Connect Opportunity video embeds
       "frame-src 'self' https://accounts.google.com https://docs.google.com https://drive.google.com https://calendar.google.com https://www.google.com https://www.youtube.com https://www.youtube-nocookie.com https://player.vimeo.com https://www.loom.com",
       // Workers needed by Pyodide (blob: for inline workers, cdn.jsdelivr.net for Pyodide worker scripts)

--- a/keystone/collab-server.js
+++ b/keystone/collab-server.js
@@ -20,6 +20,7 @@
 //   COLLAB_PORT      – optional, defaults to 4445
 // For local dev against Keystone's sqlite, run with DATABASE_URL=file:./keystone.db
 
+
 require("dotenv/config");
 
 const http = require("http");
@@ -74,6 +75,16 @@ function cardIdFromName(documentName) {
   return documentName.replace("proposalCard:", "");
 }
 
+/**
+ * Splits the document into name and ID. Has to be sent with ":" in-between
+ * @param {string} documentName 
+ * @returns {{name: string, id: string}} The parsed document name and ID
+ */
+function itemIdFromName(documentName) {
+  const splitName = documentName.split(":");
+  return { name: splitName[0], id: splitName[1] }
+}
+
 function displayName(profile) {
   if (!profile) return "Editor";
   const full = [profile.firstName, profile.lastName].filter(Boolean).join(" ");
@@ -116,43 +127,48 @@ const hocuspocus = new Hocuspocus({
     const profileId = payload && payload.itemId;
     if (!profileId) throw new Error("Unauthorized: missing profile id");
 
-    const cardId = cardIdFromName(documentName);
-
-    // The card must exist. (ProposalCard access is currently open; tighten to
-    // author/collaborator here once that is the desired policy.)
-    const card = await prisma.proposalCard.findUnique({
-      where: { id: cardId },
-      select: { id: true },
-    });
-    if (!card) throw new Error("Access denied: card not found");
-
     const profile = await prisma.profile.findUnique({
       where: { id: profileId },
       select: { username: true, firstName: true, lastName: true },
     });
 
+    // I think this is being set in the frontend? So we might be safe deleting it!
     context.user = {
       id: profileId,
       name: displayName(profile),
       color: getUserColor(profileId),
     };
+
+    const itemInfo = itemIdFromName(documentName);
+
+    const item = await prisma[itemInfo.name].findUnique({
+      where: { id: itemInfo.id },
+      select: { id: true },
+    });
+
+    if (!item) throw new Error("Access denied: item not found");
+    
+
   },
 
   async onLoadDocument({ documentName, document }) {
-    const cardId = cardIdFromName(documentName);
-    const record = await prisma.proposalCard.findUnique({
-      where: { id: cardId },
+    const item = itemIdFromName(documentName);
+    const record = await prisma[item.name].findUnique({
+      where: { id: item.id },
       select: { yjsState: true },
     });
+
     if (record && record.yjsState) {
+      console.log("Loading document from yjs-state");
       Y.applyUpdate(document, Buffer.from(record.yjsState, "base64"));
     }
-    // No yjsState yet: leave empty — the browser seeds from the card's HTML.
+    // No yjsState yet: leave empty — the client seeds from HTML or other files
+    
     return document;
   },
 
   async onStoreDocument({ documentName, document, context }) {
-    const cardId = cardIdFromName(documentName);
+    const item = itemIdFromName(documentName);
     const state = Y.encodeStateAsUpdate(document);
     const yjsState = Buffer.from(state).toString("base64");
 
@@ -162,7 +178,9 @@ const hocuspocus = new Hocuspocus({
       data.lastTimeEdited = new Date();
     }
 
-    await prisma.proposalCard.update({ where: { id: cardId }, data });
+    console.log("Storing document changes");
+    
+    await prisma[item.name].update({ where: { id: item.id }, data });
   },
 });
 

--- a/keystone/schemas/Profile.ts
+++ b/keystone/schemas/Profile.ts
@@ -489,5 +489,9 @@ export const Profile = list({
     following: relationship({ ref: "Friendship.requester", many: true }),
     followers: relationship({ ref: "Friendship.recipient", many: true }),
     yqGenAI: relationship({ ref: "YQGenAI.author", many: true }),
+    editsVisual: relationship({
+      ref: "Visual.isEditedBy",
+      many: true,
+    }),
   },
 });

--- a/keystone/schemas/YQVisual.ts
+++ b/keystone/schemas/YQVisual.ts
@@ -11,7 +11,6 @@ import {
 } from "@keystone-6/core/fields";
 import { Session } from "../types";
 
-
 // Will have to modify to new profile fields
 function getVisualFilterQuery(session: Session) {
   if (session?.data?.permissions?.some((p) => p.canAccessAdminUI)) return true;
@@ -79,10 +78,14 @@ export const Visual = list({
     },
     item: {
       update: ({ session, item }: { session?: Session; item: any }) =>
-        item.authorId == session?.itemId || session?.data?.permissions?.some((p) => p.canAccessAdminUI) || false,
+        item.authorId == session?.itemId ||
+        session?.data?.permissions?.some((p) => p.canAccessAdminUI) ||
+        false,
       create: ({ session }: { session?: Session }) => !!session,
       delete: ({ session, item }: { session?: Session; item: any }) =>
-        item.authorId == session?.itemId || session?.data?.permissions?.some((p) => p.canAccessAdminUI) || false,
+        item.authorId == session?.itemId ||
+        session?.data?.permissions?.some((p) => p.canAccessAdminUI) ||
+        false,
     },
     filter: {
       query: ({ session }) => getVisualFilterQuery(session),
@@ -110,6 +113,15 @@ export const Visual = list({
     docs: json(),
     docsVisible: checkbox(),
     published: checkbox(),
+    lastTimeEdited: timestamp(),
+    yjsState: text({
+      ui: {
+        createView: { fieldMode: "hidden" },
+        itemView: { fieldMode: "hidden" },
+        listView: { fieldMode: "hidden" },
+      },
+    }),
+    isEditedBy: relationship({ref: "Profile.editsVisual"}),
     tags: relationship({ ref: "YQTag.visuals", many: true }),
     privacy: select({
       options: [


### PR DESCRIPTION
Changes:
* Changed profile and visual schema to support storing the yjs document and keeping track of recent editing.
* Changed the collab server endpoint to generalize storing into the backend (check for potential security flaws)
* Changed frontend secure content policy & collab endpoints to allow accessing the collab server on local development.
> [!WARNING]
> This might create merge conflicts, so feel free to discard changes to the config file and copy-paste the new endpoint: `ws://localhost:4445`